### PR TITLE
Add filetype detection to fix_license_header

### DIFF
--- a/fix_license_header/fix_license_header.py
+++ b/fix_license_header/fix_license_header.py
@@ -73,6 +73,7 @@ def fix_file(f, header_lines, prefix, keep_before, keep_after):
 file_type_comment_map = {
     'asm': ';',  # Assembly
     'c': '//',  # C
+    'cc': '//',  # C++
     'cpp': '//',  # C++
     'c++': '//',  # C++
     'cs': '//',  # C#
@@ -84,6 +85,7 @@ file_type_comment_map = {
     'h': '//',  # C header
     'hpp': '//',  # C++ header
     'h++': '//',  # C++ header
+    'inc': '//',  # C++ template include file
     'java': '//',  # Java
     'js': '//',  # Javascript
     'json': '//',  # JSON

--- a/fix_license_header/fix_license_header.py
+++ b/fix_license_header/fix_license_header.py
@@ -184,14 +184,14 @@ def main(argv=None):
         if args.comment_prefix is None:
             # Parse to search for stored comment prefix for that file type.
             extension = filename.split('.')[-1]
-            prefix = file_type_comment_map.get('extension', None)
+            prefix = file_type_comment_map.get(extension, None)
             if prefix is None:
                 error_str = (
-                    f"Comment prefix for '.{extension}' file could not be found "
-                    'automatically.\nPlease provide the correct value with '
-                    '--comment-prefix'
+                    f'Comment format not detected for file with extension {extension}.'
+                    ' Please provide the correct value with --comment-prefix',
                 )
                 raise ValueError(error_str)
+                continue
         else:
             prefix = args.comment_prefix
         with open(filename, 'r+b') as f:

--- a/fix_license_header/fix_license_header.py
+++ b/fix_license_header/fix_license_header.py
@@ -188,7 +188,7 @@ def main(argv=None):
             if prefix is None:
                 error_str = (
                     f"Comment prefix for '.{extension}' file could not be found "
-                    'automatically.\nPlease provide the correct value with'
+                    'automatically.\nPlease provide the correct value with '
                     '--comment-prefix'
                 )
                 raise ValueError(error_str)

--- a/fix_license_header/fix_license_header.py
+++ b/fix_license_header/fix_license_header.py
@@ -192,14 +192,13 @@ def main(argv=None):
                     '--comment-prefix'
                 )
                 raise ValueError(error_str)
-            prefix = prefix.encode('utf-8') + b' '
         else:
-            prefix = args.comment_prefix.encode('utf-8') + b' '
+            prefix = args.comment_prefix
         with open(filename, 'r+b') as f:
             status = fix_file(
                 f=f,
                 header_lines=header_lines,
-                prefix=prefix,
+                prefix=prefix.encode('utf-8') + b' ',
                 keep_before=keep_before,
                 keep_after=keep_after,
             )

--- a/fix_license_header/fix_license_header.py
+++ b/fix_license_header/fix_license_header.py
@@ -76,6 +76,8 @@ file_type_comment_map = {
     'cpp': '//',  # C++
     'c++': '//',  # C++
     'cs': '//',  # C#
+    'cu': '//',  # CUDA
+    'cuh': '//',  # CUDA header
     'dockerfile': '#',  # Docker files
     'gleam': '//',  # Gleam
     'go': '//',  # Golang


### PR DESCRIPTION
Previously, filetypes with different comment strings would require separate calls to the pre-commit hook. By detecting the file type of common files, this requirement is lifted. Note that less common programming languages (those whose comment style is not stored in the internal database) will require separate blocks.

## How does it work?

If `--comment-prefix` is not set, the extension of each file the hook runs on is compared against a dictionary of known values. If that key exists, the hook reads the correct value and if it does not, a nicely formatted `ValueError` is raised.


## NOTE
The code is not tested as of yet, as the pre-commit hook pulls from the remote repo. If you have any idea how to pull from the local installation I would love to hear it.

### Before
```yaml
- repo: https://github.com/glotzerlab/fix-license-header
  rev: v0.2.0
  hooks:
  - id: fix-license-header
    name: Fix license headers (Python)
    types_or: [python, cython]
    args:
    - --license-file=LICENSE
    - --add=Part of GSD, released under the BSD 2-Clause License.
    - --keep-before=#!
  - id: fix-license-header
    name: Fix license headers (C)
    types_or: [c]
    args:
    - --license-file=LICENSE
    - --add=Part of GSD, released under the BSD 2-Clause License.
    - --comment-prefix=//
```

### After
```yaml
- repo: https://github.com/glotzerlab/fix-license-header
  rev: v0.2.0
  hooks:
  - id: fix-license-header
    name: Fix license headers
    types_or: [python, cython, c]
    args:
    - --license-file=LICENSE
    - --add=Part of GSD, released under the BSD 2-Clause License.
    - --keep-before=#!
```